### PR TITLE
Change to build binary inside docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+CONTRIBUTING.md
+Dockerfile
+README.md
+api/
+docker/
+docs/
+test-send.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
 FROM golang:1.22.1
 
-COPY federation /app/
+COPY . /src/
+
+WORKDIR /app
+RUN cd /src \
+    && go mod download \
+    && go build -o /app/federation /src/cmd/federation.go \
+    && cd /app \
+    && rm -rf /src
 
 EXPOSE 8080
 


### PR DESCRIPTION
This should solve the problem with arm builds as it now generates the binary inside the final docker image so that the binary itself is generated by the correct architecture