### PR TITLE
Add healthcheck endpoint

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -11,6 +11,7 @@ import (
 
 type Database interface {
 	Connect() error
+	Ping() bool
 	RunMigrations()
 	Find(interface{}, ...interface{}) error
 	Save(interface{}) error
@@ -19,6 +20,10 @@ type Database interface {
 func (db *PostgresDB) Find(data interface{}, conds ...interface{}) error {
 	db.tx = db.DB.Find(data, conds)
 	return db.tx.Error
+}
+
+func (db *PostgresDB) Ping() bool {
+	return db.DB.Exec("SELECT 1").Error == nil
 }
 
 type PostgresDB struct {

--- a/internal/http/internal.go
+++ b/internal/http/internal.go
@@ -1,0 +1,65 @@
+package http
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type Health struct {
+	Status  string                     `json:"status"`
+	Message string                     `json:"message,omitempty"`
+	Queue   map[string]map[string]bool `json:"queue"`
+	DB      bool                       `json:"db"`
+}
+
+func (server *Server) SetupInternalRoutes() {
+	server.Router.HandleFunc("/internal/health", server.getHealthHandler).Methods("GET")
+
+	// Keeping this for the moment to not break existing health check
+	server.Router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}).Methods("GET")
+}
+
+func (server *Server) getHealthHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add("content-type", "application/json")
+	health := Health{Status: "ok"}
+	health.DB = server.Database.Ping()
+	health.Queue = server.Queue.Status()
+	if !health.DB {
+		health.Status = "error"
+		health.Message = "Database is not ok"
+		w.WriteHeader(http.StatusInternalServerError)
+	} else if !server.checkQueueHealth(&health) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+	if health.Status == "ok" {
+		w.WriteHeader(http.StatusOK)
+	}
+	content, _ := json.MarshalIndent(health, "", "  ")
+	_, err := w.Write(content)
+	if err != nil {
+		server.Logger.Error("Error writing response", err)
+	}
+}
+
+func (server *Server) checkQueueHealth(health *Health) bool {
+	// No consumers is a problem. However, it's (probably) ok if we have no producers
+	// as we might not have sent any messages yet.
+	if len(health.Queue["consumers"]) == 0 {
+		health.Status = "error"
+		health.Message = "No consumers"
+		return false
+	}
+	for queueType, status := range health.Queue {
+		for queueName, ok := range status {
+			if !ok {
+				health.Status = "error"
+				health.Message = fmt.Sprintf("%s queue '%s' is not ok", queueType, queueName)
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -43,10 +43,7 @@ func (server *Server) RunServer() {
 	flag.DurationVar(&wait, "graceful-timeout", time.Second*15, "the duration for which the server gracefully wait for existing connections to finish - e.g. 15s or 1m")
 	flag.Parse()
 
-	// Should do something better than this, but for now I need / to return 200 for healthcheck in docker-compose
-	server.Router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}).Methods("GET")
+	server.SetupInternalRoutes()
 	server.SetupUserRoutes()
 	server.SetupPostRoutes()
 	server.SetupApubRoutes()


### PR DESCRIPTION
This PR adds a new endpoint to be used for healthchecks. It returns a dynamic response checking dependencies of the service to determine actual healthiness of service. 

Healthy response looks like:
```
HTTP/1.1 200 OK
Content-Type: application/json
Date: Sat, 23 Mar 2024 08:07:40 GMT
Content-Length: 158

{
  "status": "ok",
  "queue": {
    "consumers": {
      "actor_create_queue": true,
      "post_queue": true
    },
    "publishers": {}
  },
  "db": true
}
```

And an unhealthy response might look like:
```
HTTP/1.1 500 Internal Server Error
Content-Type: application/json
Date: Sat, 23 Mar 2024 08:20:17 GMT
Content-Length: 197

{
  "status": "error",
  "message": "Database is not ok",
  "queue": {
    "consumers": {
      "actor_create_queue": true,
      "post_queue": true
    },
    "publishers": {}
  },
  "db": false
}
```