### PR TITLE
Push to Docker Hub instead of GitHub packages

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,8 +14,7 @@ on:
     branches: [ "main" ]
 
 env:
-  # Use docker.io for Docker Hub if empty
-  REGISTRY: ghcr.io
+  REGISTRY: docker.io
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
 
@@ -84,13 +83,12 @@ jobs:
 
     # Login against a Docker registry except on PR
     # https://github.com/docker/login-action
-    - name: Log into registry ${{ env.REGISTRY }}
+    - name: Log into Docker Hub
       if: github.event_name != 'pull_request'
-      uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+      uses: docker/login-action@v3
       with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
 
     # Extract metadata (tags, labels) for Docker
     # https://github.com/docker/metadata-action

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM golang:1.22.1
+LABEL maintainer="Sublinks Core Developers <hello@sublinks.org>"
+LABEL description="Federation service for Sublinks"
 
 COPY . /src/
 


### PR DESCRIPTION
Change to use Docker Hub for image hosting instead of GitHub because GitHub does not allow anonymous downloads